### PR TITLE
feat: Add COUNTDOWN_DAYS and COUNTDOWN_TIME content providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,24 @@ No automated test suite exists. Test manually with `pnpm dev` and watch console 
 
 ## Architecture
 
-Node.js app (ES modules) that runs as a cron job, checks an ICS calendar for current events, and updates a physical Vestaboard display.
+ES modules app that runs as a cron job, checks an ICS calendar for current events, and updates a physical Vestaboard display. There are two execution modes sharing the same core logic:
 
-**Flow:** `index.js` (bootstrap) → `src/config.js` (validate env) → `src/scheduler.js` (cron) → on each tick: `src/calendar.js` (fetch/parse ICS, find current event) → `src/content-providers/index.js` (resolve dynamic content if keyword match) → `src/vestaboard.js` (compose text to 6x22 character grid, push to board API)
+**Cloudflare Worker mode** (primary, `src/index.js`): Exports a `scheduled` handler triggered by Wrangler's cron (configured in `wrangler.toml` as `*/1 6-22 * * *`). Env vars come from the Worker environment. Flow: `src/index.js` → `src/calendar.js` → `src/content-providers/index.js` → `src/vestaboard.js`.
 
-**Content provider system:** Calendar event titles matching keywords (`WEATHER`, `LUNCH`, `QUOTE`, `URL:...`, `COLOR_*`, `SAVE`, `RESTORE`) route through `src/content-providers/index.js` to specialized modules (`weather.js`, `lunch.js`, `quote.js`, `url-fetcher.js`, `colors.js`). State management (`SAVE`/`RESTORE`) uses `src/storage.js`. Non-keyword titles display as static text.
+**Node.js mode** (`index.js`): Standalone entry for local long-running execution. Flow: `index.js` → `src/config.js` (validate env via `process.env`) → `src/scheduler.js` (node-cron) → same core modules on each tick.
+
+**Content provider system:** Calendar event titles matching keywords route through `src/content-providers/index.js` to specialized modules. Non-keyword titles display as static text.
+
+| Keyword | Module | Notes |
+|---|---|---|
+| `WEATHER` | `weather.js` | Requires OpenWeather config |
+| `LUNCH` | `lunch.js` | |
+| `QUOTE` | `quote.js` | |
+| `URL:https://...` | `url-fetcher.js` | URL follows colon |
+| `COLOR_RANDOM`, `COLOR_VERTICAL`, `COLOR_HORIZONTAL`, `COLOR_DIAGONAL` | `colors.js` | Returns raw 2D color-code array |
+| `SAVE` / `RESTORE` | `storage.js` | Saves/restores board state; no board write |
+| `COUNTDOWN_DAYS MM/DD/YY Title` | `countdown.js` | Shows days remaining on line 1, title on line 2 |
+| `COUNTDOWN_TIME MM/DD/YY HH:MM:SS Title` | `countdown.js` | Shows labeled time units on line 1 (e.g. `2d 3h 15m 30s`), title on line 2; leading zero units suppressed; expired = no board update |
 
 **Vestaboard API:** Text → compose endpoint (`vbml.vestaboard.com/compose`) converts to character codes → update endpoint (`rw.vestaboard.com/`) writes to board. Color grids bypass compose and send raw 2D arrays directly. Auth via `X-Vestaboard-Read-Write-Key` header.
 
@@ -33,4 +46,4 @@ Node.js app (ES modules) that runs as a cron job, checks an ICS calendar for cur
 
 ## Configuration
 
-Required env vars: `ICS_CALENDAR_URL`, `VESTABOARD_API_KEY`. Optional: `OPENWEATHER_API_KEY`/`OPENWEATHER_LAT`/`OPENWEATHER_LON` (for WEATHER), `STATE_STORAGE_PATH`, `CRON_SCHEDULE`. Local dev uses `.dev.vars` (never committed). Cloudflare secrets via `npx wrangler secret put <KEY>`.
+Required env vars: `ICS_CALENDAR_URL`, `VESTABOARD_API_KEY`. Optional: `OPENWEATHER_API_KEY`/`OPENWEATHER_LAT`/`OPENWEATHER_LON` (for WEATHER), `STATE_STORAGE_PATH`, `CRON_SCHEDULE`, `TIMEZONE` (default `America/Chicago`, used by countdown providers). Local dev uses `.dev.vars` (never committed). Cloudflare secrets via `npx wrangler secret put <KEY>`.

--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,7 @@ export const loadConfig = () => {
     OPENWEATHER_LAT: process.env.OPENWEATHER_LAT,
     OPENWEATHER_LON: process.env.OPENWEATHER_LON,
     STATE_STORAGE_PATH: process.env.STATE_STORAGE_PATH || './vestaboard-state.json',
+    TIMEZONE: process.env.TIMEZONE || 'America/Chicago',
   };
 
   // Validate required config

--- a/src/content-providers/countdown.js
+++ b/src/content-providers/countdown.js
@@ -1,0 +1,95 @@
+import { DateTime } from 'luxon';
+
+const parseCountdownArgs = (rawTitle, keyword, dateTokenCount, timezone) => {
+  const rest = rawTitle.slice(keyword.length).trim();
+  const tokens = rest.split(/\s+/);
+
+  if (tokens.length < dateTokenCount + 1) {
+    throw new Error(`${keyword}: expected date${dateTokenCount === 2 ? ' and time' : ''} followed by title, got: "${rest}"`);
+  }
+
+  const dateStr = tokens[0];
+  const timeStr = dateTokenCount === 2 ? tokens[1] : null;
+  const displayTitle = tokens.slice(dateTokenCount).join(' ');
+
+  if (!displayTitle) {
+    throw new Error(`${keyword}: missing title text`);
+  }
+
+  const targetDate = timeStr
+    ? DateTime.fromFormat(`${dateStr} ${timeStr}`, 'MM/dd/yy HH:mm:ss', { zone: timezone })
+    : DateTime.fromFormat(dateStr, 'MM/dd/yy', { zone: timezone }).startOf('day');
+
+  if (!targetDate.isValid) {
+    throw new Error(`${keyword}: invalid date/time — ${targetDate.invalidExplanation}`);
+  }
+
+  return { targetDate, displayTitle };
+};
+
+const formatTimeLine = (diff) => {
+  const { days, hours, minutes, seconds } = diff
+    .shiftTo('days', 'hours', 'minutes', 'seconds')
+    .toObject();
+
+  const parts = [
+    { value: Math.floor(days),    label: 'd' },
+    { value: Math.floor(hours),   label: 'h' },
+    { value: Math.floor(minutes), label: 'm' },
+    { value: Math.floor(seconds), label: 's' },
+  ];
+
+  const firstNonZero = parts.findIndex(({ value }) => value >= 1);
+  const displayParts = firstNonZero === -1
+    ? [{ value: 0, label: 's' }]
+    : parts.slice(firstNonZero);
+
+  return displayParts.map(({ value, label }) => `${value}${label}`).join(' ');
+};
+
+export const getCountdownDaysContent = async (rawTitle, config) => {
+  const keyword = 'COUNTDOWN_DAYS';
+  const timezone = config.TIMEZONE;
+  console.log(`countdown: processing ${keyword}`);
+  try {
+    const { targetDate, displayTitle } = parseCountdownArgs(rawTitle, keyword, 1, timezone);
+    const now = DateTime.now().setZone(timezone);
+    const daysRemaining = Math.floor(
+      targetDate.startOf('day').diff(now.startOf('day'), 'days').days
+    );
+
+    if (daysRemaining <= 0) {
+      console.log(`countdown: ${keyword} target has passed or is today, skipping board update`);
+      return { action: 'countdown_expired', skipBoardUpdate: true };
+    }
+
+    console.log(`countdown: ${daysRemaining} days until "${displayTitle}"`);
+    return `${daysRemaining}\n${displayTitle}`;
+  } catch (error) {
+    console.error(`countdown: ${keyword} error —`, error.message);
+    return 'Countdown unavailable';
+  }
+};
+
+export const getCountdownTimeContent = async (rawTitle, config) => {
+  const keyword = 'COUNTDOWN_TIME';
+  const timezone = config.TIMEZONE;
+  console.log(`countdown: processing ${keyword}`);
+  try {
+    const { targetDate, displayTitle } = parseCountdownArgs(rawTitle, keyword, 2, timezone);
+    const now = DateTime.now().setZone(timezone);
+    const diff = targetDate.diff(now);
+
+    if (diff.as('milliseconds') <= 0) {
+      console.log(`countdown: ${keyword} target has passed, skipping board update`);
+      return { action: 'countdown_expired', skipBoardUpdate: true };
+    }
+
+    const timeLine = formatTimeLine(diff);
+    console.log(`countdown: ${timeLine} until "${displayTitle}"`);
+    return `${timeLine}\n${displayTitle}`;
+  } catch (error) {
+    console.error(`countdown: ${keyword} error —`, error.message);
+    return 'Countdown unavailable';
+  }
+};

--- a/src/content-providers/index.js
+++ b/src/content-providers/index.js
@@ -3,6 +3,7 @@ import { getLunchContent } from './lunch.js';
 import { getUrlContent } from './url-fetcher.js';
 import { getColorContent } from './colors.js';
 import { getQuoteContent } from './quote.js';
+import { getCountdownDaysContent, getCountdownTimeContent } from './countdown.js';
 import { getCurrentState, saveCurrentState, restoreState } from '../storage.js';
 
 /**
@@ -25,6 +26,17 @@ export const resolveDynamicContent = async (eventTitle, config) => {
       console.log('Detected URL content provider');
       return await getUrlContent(url);
     }
+  }
+
+  // Check for countdown providers (keyword + space prefix with date/time arguments)
+  if (title.toUpperCase().startsWith('COUNTDOWN_DAYS ')) {
+    console.log('Detected COUNTDOWN_DAYS content provider');
+    return await getCountdownDaysContent(title, config);
+  }
+
+  if (title.toUpperCase().startsWith('COUNTDOWN_TIME ')) {
+    console.log('Detected COUNTDOWN_TIME content provider');
+    return await getCountdownTimeContent(title, config);
   }
 
   // Check for predefined keywords

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export default {
       OPENWEATHER_LAT: env.OPENWEATHER_LAT,
       OPENWEATHER_LON: env.OPENWEATHER_LON,
       STATE_STORAGE_PATH: env.STATE_STORAGE_PATH || './vestaboard-state.json',
+      TIMEZONE: env.TIMEZONE || 'America/Chicago',
     };
 
     console.log('Config check:', {


### PR DESCRIPTION
Adds countdown.js with two new calendar event keywords:
- COUNTDOWN_DAYS: shows days remaining to a target date
- COUNTDOWN_TIME: shows labeled time units (d/h/m/s) with leading zeros suppressed

Also adds TIMEZONE env var support (default: America/Chicago) and updates CLAUDE.md with content provider table and dual-mode architecture docs.